### PR TITLE
gh-actions: Add initial CI workflow to cover basic linting checks and unit testing.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,40 @@
+name: "CI"
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  # Cancel in-progress jobs for efficiency
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-latest"]
+    runs-on: "${{matrix.os}}"
+    steps:
+      - uses: "actions/checkout@v4"
+
+      - name: "Install Rust toolchain"
+        run: rustup show
+
+      - name: "Install Rust fmt toolchain"
+        run: rustup component add rustfmt
+
+      - name: "Install cargo nextest"
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: "Cargo fmt"
+        run: cargo fmt --all --check
+
+      - name: "Cargo check"
+        run: cargo check
+
+      - name: "Cargo test"
+        run: cargo nextest run --all-features


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds the initial CI workflow on every push and pull request. The following features are covered:
- Format linting check using `cargo fmt`
- Static analysis using `cargo check`
- Unit testing using [`nextest`](https://nexte.st/)

The CI workflow will run on both macOS and Ubuntu Linux.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
Ensure the workflow passed on my own fork: https://github.com/LinZhihao-723/log-surgeon-rust/actions/runs/11321309379

