### PR TITLE
feat: Add facade wrapper for `regex_syntax::ast::parse::Parser` to parse regular expressions into an AST.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,12 @@ version = 3
 [[package]]
 name = "log-surgeon"
 version = "0.0.1"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
+regex-syntax = "0.8.5"

--- a/src/error_handling/error.rs
+++ b/src/error_handling/error.rs
@@ -1,0 +1,8 @@
+use regex_syntax::ast;
+
+#[derive(Debug)]
+pub enum Error {
+    RegexParsingError(ast::Error),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/error_handling/mod.rs
+++ b/src/error_handling/mod.rs
@@ -1,0 +1,3 @@
+mod error;
+pub use error::Error;
+pub use error::Result;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod error_handling;
 mod nfa;
 pub mod parser;
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,2 +1,3 @@
 // Keep ASTNode private and they will be used by parser in the future
 pub(crate) mod ast_node;
+mod regex_parser;

--- a/src/parser/regex_parser/mod.rs
+++ b/src/parser/regex_parser/mod.rs
@@ -1,0 +1,1 @@
+pub mod parser;

--- a/src/parser/regex_parser/parser.rs
+++ b/src/parser/regex_parser/parser.rs
@@ -1,0 +1,58 @@
+use crate::error_handling::{Error, Error::RegexParsingError, Result};
+use regex_syntax::ast::{parse::Parser, Ast};
+
+// This is a wrapper of `regex_syntax::ast::parse::Parser`, which can be extended to hold
+// program-specific data members.
+pub struct RegexParser {
+    m_parser: Parser,
+}
+
+impl RegexParser {
+    pub fn new() -> RegexParser {
+        Self {
+            m_parser: Parser::new(),
+        }
+    }
+
+    pub fn parse_into_ast(&mut self, pattern: &str) -> Result<Ast> {
+        match self.m_parser.parse(pattern) {
+            Ok(ast) => Ok(ast),
+            Err(e) => Err(RegexParsingError(e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex_syntax::ast;
+
+    #[test]
+    fn test_basic_parsing() {
+        let mut parser = RegexParser::new();
+        let parse_result = parser.parse_into_ast(r"[a-t\d]");
+        assert!(parse_result.is_ok());
+        let Ast::ClassBracketed(bracket_ast) = &parse_result.unwrap() else {
+            panic!("Type mismatched")
+        };
+        let ast::ClassSet::Item(item) = &bracket_ast.kind else {
+            panic!("Type mismatched")
+        };
+        let ast::ClassSetItem::Union(union) = &item else {
+            panic!("Type mismatched")
+        };
+        let a_to_z_item = &union.items[0];
+        let ast::ClassSetItem::Range(range) = &a_to_z_item else {
+            panic!("Type mismatched")
+        };
+        assert_eq!(range.start.c, 'a');
+        assert_eq!(range.end.c, 't');
+        let digit_item = &union.items[1];
+        let ast::ClassSetItem::Perl(perl) = &digit_item else {
+            panic!("Type mismatched")
+        };
+        let ast::ClassPerlKind::Digit = &perl.kind else {
+            panic!("Type mismatched")
+        };
+    }
+}


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR introduces a facade wrapper for `regex_syntax::ast::parse::Parser`, which is used to parse regular expressions into an AST. A small unit test case is added to show how to traverse through the AST (despite the testing code being very verbose).
The future PRs will be built upon the ASTs generated by this parser.
This PR also adds an error type and a result type to standardize the error handling across this project.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure the workflow passed.

