### PR TITLE
build: Add `regex-engine` feature to expose NFA and DFA APIs.

### DIFF
--- a/src/dfa/dfa.rs
+++ b/src/dfa/dfa.rs
@@ -45,7 +45,7 @@ impl Debug for Transition {
     }
 }
 
-pub(crate) struct DFA {
+pub struct DFA {
     start: State,
     accept: Vec<State>,
     states: Vec<State>,
@@ -79,7 +79,7 @@ impl Debug for DFA {
     }
 }
 
-pub(crate) struct DfaSimulator {
+pub struct DfaSimulator {
     dfa: Rc<DFA>,
     current_state: State,
 }

--- a/src/dfa/mod.rs
+++ b/src/dfa/mod.rs
@@ -1,5 +1,8 @@
-mod dfa;
+pub(crate) mod dfa;
 
-pub(crate) use dfa::DfaSimulator;
-pub(crate) use dfa::State;
-pub(crate) use dfa::DFA;
+#[cfg(feature = "regex-engine")]
+pub use dfa::DfaSimulator;
+#[cfg(feature = "regex-engine")]
+pub use dfa::State;
+#[cfg(feature = "regex-engine")]
+pub use dfa::DFA;

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -1,4 +1,4 @@
-use crate::dfa::{State, DFA};
+use crate::dfa::dfa::{State, DFA};
 use crate::error_handling::Error::{LexerInputStreamNotSet, LexerInternalErr, LexerStateUnknown};
 use crate::error_handling::Result;
 use crate::lexer::LexerStream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,17 @@
-mod dfa;
 pub mod error_handling;
 pub mod lexer;
 pub mod log_parser;
-mod nfa;
 pub mod parser;
+
+#[cfg(feature = "regex-engine")]
+pub mod dfa;
+#[cfg(feature = "regex-engine")]
+pub mod nfa;
+
+#[cfg(not(feature = "regex-engine"))]
+mod dfa;
+#[cfg(not(feature = "regex-engine"))]
+mod nfa;
 
 const VERSION: &str = "0.0.1";
 

--- a/src/nfa/mod.rs
+++ b/src/nfa/mod.rs
@@ -1,1 +1,10 @@
-pub mod nfa;
+pub(crate) mod nfa;
+
+#[cfg(feature = "regex-engine")]
+pub use crate::nfa::nfa::State;
+
+#[cfg(feature = "regex-engine")]
+pub use crate::nfa::nfa::NFA;
+
+#[cfg(feature = "regex-engine")]
+pub use crate::nfa::nfa::Transition;

--- a/src/nfa/nfa.rs
+++ b/src/nfa/nfa.rs
@@ -24,7 +24,7 @@ const EPSILON_TRANSITION: u128 = 0x0;
 const DOT_TRANSITION: u128 = !EPSILON_TRANSITION;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct State(pub usize);
+pub struct State(pub usize);
 
 pub struct Transition {
     from: State,
@@ -115,7 +115,7 @@ impl Transition {
     }
 }
 
-pub(crate) struct NFA {
+pub struct NFA {
     start: State,
     accept: State,
     states: Vec<State>,


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR adds a library feature, `regex-engine` (off by default), to expose NFA and DFA APIs.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure workflows all passed.
- Manually tested using the example program to use NFA and DFA APIs when `regex-engine` feature is on.

