### PR TITLE
fix: Preserve schema variables' ordering when parsing from the input YAML config file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -123,6 +124,7 @@ name = "log-surgeon"
 version = "0.0.1"
 dependencies = [
  "clap",
+ "indexmap",
  "regex-syntax",
  "serde_yaml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 
 [dependencies]
 clap = "4.5.23"
+indexmap = { version = "2.7.0", features = ["serde"] }
 regex-syntax = "0.8.5"
 serde_yaml = "0.9.34"

--- a/examples/schema.yaml
+++ b/examples/schema.yaml
@@ -17,5 +17,5 @@ variables:
   float: '\-{0,1}[0-9]+\.[0-9]+'
   hex: '0x(((\d|[a-f])+)|((\d|[A-F])+))'
   loglevel: '(INFO)|(DEBUG)|(WARN)|(ERROR)|(TRACE)|(FATAL)'
-  thread_identifier: '\[(\w)+\]'
+  field_identifier: '\[(\w)+\]'
   path: '(/(\w|\.|\-|\*)+)+(/)*'


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Before this PR, the ordering of the given schema is not preserved because of the nature of HashMap. This PR solves the problem by using `IndexMap` instead to store the parsed result.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure all workflows passed.
- Ensure newly added unit tests passed that check the ordering.

