### PR TITLE
perf: Let the lexer operate on `u8` instead of `char` to improve read performance.

### DIFF
--- a/examples/logs/hive-24h_large.log
+++ b/examples/logs/hive-24h_large.log
@@ -11,6 +11,7 @@
  - UUID:0xddba9b95eeb3cfb9ccb3d8401d1610d42f0e3aad
  - HashIndex:0xad56993d052a6b692268e8aa013dd02e37e082bf
 2015-03-23 08:09:27,194 INFO [main] org.apache.hadoop.hive.ql.log.PerfLogger: <PERFLOG method=deserializePlan from=org.apache.hadoop.hive.ql.exec.Utilities>
+2015-03-23 08:09:27,194 INFO [main] org.apache.hadoop.hive.ql.log.PerfLogger: 哥们儿来点中文试试
 2015-03-23 08:09:27,194 INFO [main] org.apache.hadoop.hive.ql.exec.Utilities: Deserializing MapWork via kryo
 2015-03-23 08:09:28,203 INFO [main] org.apache.hadoop.hive.ql.log.PerfLogger: </PERFLOG method=deserializePlan start=1427098167194 end=1427098168203 duration=1009 from=org.apache.hadoop.hive.ql.exec.Utilities>
 2015-03-23 08:09:28,337 INFO [main] org.apache.hadoop.io.compress.zlib.ZlibFactory: Successfully loaded & initialized native-zlib library

--- a/src/dfa/dfa.rs
+++ b/src/dfa/dfa.rs
@@ -227,10 +227,10 @@ impl DFA {
 
 impl DFA {
     pub fn get_next_state(&self, state: State, c: u8) -> Option<State> {
-        let transitions = &self.transitions[state.0];
         if 128 <= c {
             return None;
         }
+        let transitions = &self.transitions[state.0];
         match &transitions[c as usize] {
             Some(transition) => Some(transition.to_state.clone()),
             None => None,

--- a/src/lexer/lexer_stream.rs
+++ b/src/lexer/lexer_stream.rs
@@ -1,5 +1,5 @@
 use crate::error_handling::Result;
 
 pub trait LexerStream {
-    fn get_next_char(&mut self) -> Result<Option<char>>;
+    fn get_next_char(&mut self) -> Result<Option<u8>>;
 }

--- a/src/lexer/streams.rs
+++ b/src/lexer/streams.rs
@@ -3,13 +3,13 @@ use crate::error_handling::Error::IOError;
 use crate::error_handling::Result;
 use std::io::{self, BufReader, Read};
 
-const BUF_SIZE: usize = 4096 * 16;
+const BUF_SIZE: usize = 4096 * 8;
 
 pub struct BufferedFileStream {
     buf_reader: BufReader<std::fs::File>,
     pos: usize,
     end: usize,
-    buffer: [u8; 4096],
+    buffer: [u8; BUF_SIZE],
 }
 
 impl BufferedFileStream {
@@ -19,7 +19,7 @@ impl BufferedFileStream {
                 buf_reader: BufReader::new(file),
                 pos: 0,
                 end: 0,
-                buffer: [0; 4096],
+                buffer: [0; BUF_SIZE],
             }),
             Err(e) => Err(IOError(e)),
         }

--- a/src/log_parser/log_parser.rs
+++ b/src/log_parser/log_parser.rs
@@ -124,7 +124,7 @@ impl LogEvent {
     pub fn to_string(&self) -> String {
         let mut result = String::new();
         for token in &self.tokens {
-            result += &token.get_val();
+            result += &token.get_buf_as_string();
         }
         result
     }
@@ -151,7 +151,7 @@ impl Debug for LogEvent {
                         "\t[Var({:?})|{}]: \"{}\"\n",
                         self.schema_config.get_var_schemas()[var_id].name,
                         token.get_line_num(),
-                        token.get_val().escape_default()
+                        token.get_buf_as_string().escape_default()
                     )
                     .as_str()
                 }
@@ -160,7 +160,7 @@ impl Debug for LogEvent {
                         "\t[Timestamp({})|{}]: \"{}\"\n",
                         ts_id,
                         token.get_line_num(),
-                        token.get_val().escape_default()
+                        token.get_buf_as_string().escape_default()
                     )
                     .as_str()
                 }
@@ -169,7 +169,7 @@ impl Debug for LogEvent {
                         "\t[{:?}|{}]: \"{}\"\n",
                         token.get_token_type(),
                         token.get_line_num(),
-                        token.get_val().escape_default()
+                        token.get_buf_as_string().escape_default()
                     )
                     .as_str()
                 }

--- a/src/parser/schema_parser/parser.rs
+++ b/src/parser/schema_parser/parser.rs
@@ -71,8 +71,8 @@ impl SchemaConfig {
         &self.var_schemas
     }
 
-    pub fn has_delimiter(&self, delimiter: char) -> bool {
-        if false == delimiter.is_ascii() {
+    pub fn has_delimiter(&self, delimiter: u8) -> bool {
+        if 128 <= delimiter {
             return false;
         }
         self.delimiters[delimiter as usize]
@@ -191,7 +191,7 @@ mod tests {
 
         let delimiters: Vec<char> = vec![' ', '\t', '\n', '\r', ':', ',', '!', ';', '%'];
         for delimiter in delimiters {
-            assert!(parsed_schema.has_delimiter(delimiter));
+            assert!(parsed_schema.has_delimiter(delimiter as u8));
         }
 
         Ok(())

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -43,7 +43,7 @@ fn test_lexer_simple() -> Result<()> {
                 parsed_line.clear();
                 curr_line_num += 1;
             }
-            parsed_line += &token.get_val().to_string();
+            parsed_line += &token.get_buf_as_string().to_string();
             println!("{:?}", token);
         }
         parsed_lines.push(parsed_line.clone());


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
When reading `char`, the underlying reader has to do utf8 validation, which is slow and unnecessary in our use case. This PR changes the lexer to directly operate on `u8`, which increases the performance by ~15% in the benchmark data set.


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
- Ensure all workflows passed.
- Ensure example works well, with unicode handled
- Ensure benchmark performance gets better

